### PR TITLE
fix: git branch --show-current

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ function __build_deps_check() {
 function build() {
   __build_deps_check
   cd ${PIPY_DIR}
-  BRANCH=`git branch --show-current`
+  BRANCH=`git rev-parse --abbrev-ref HEAD`
   git fetch
   git pull origin $BRANCH
   export CC=clang


### PR DESCRIPTION
When using a git version lower than 3.0 , 
the command  ”git branch --show-current“   under build.sh will report an error  like inssue: https://github.com/flomesh-io/pipy/issues/23

So, replace it with another command to implement similar functionality