### PR TITLE
Fixes Clang13 sigsev issue

### DIFF
--- a/generate_version_h.sh
+++ b/generate_version_h.sh
@@ -5,7 +5,7 @@ if [ -n "$CI_COMMIT_SHA" ]; then
   COMMIT="$CI_COMMIT_SHA"
   COMMIT_DATE="$CI_COMMIT_DATE"
 else
-  VERSION="0.0.0"
+  VERSION=`git describe --abbrev=0 --tags`
   COMMIT=`git log -1 --format=%H`
   COMMIT_DATE=`git log -1 --format=%cD`
 fi

--- a/src/pjs/types.hpp
+++ b/src/pjs/types.hpp
@@ -2125,7 +2125,7 @@ public:
 
 private:
   Array(size_t size = 0)
-    : m_data(Data::make(std::max(2, 1 << power(std::max(0, int(size))))))
+    : m_data(Data::make(std::max(1, 1 << power(size))))
     , m_size(size) {}
 
   ~Array() {
@@ -2137,7 +2137,7 @@ private:
   int m_size;
 
   static auto power(size_t size) -> size_t {
-    return sizeof(unsigned int) * 8 - __builtin_clz(size - 1);
+    return size == 0 ? 1 : sizeof(unsigned int) * 8 - __builtin_clz(size);
   }
 
   friend class ObjectTemplate<Array>;


### PR DESCRIPTION
- Fixes issues where code compiled with clang13 in release mode was segfaulting
- updated `generate_version_h.sh` to retrieve version info from local git repo, previously it was hard-coded as "0.0.0"