### PR TITLE
Updated cmake version and added modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1.0)
+cmake_minimum_required (VERSION 3.10)
 project(pipy)
 
 option(PIPY_GUI "include builtin GUI" ON)
@@ -21,7 +21,20 @@ option(LEVELDB_INSTALL "Install LevelDB's header and library" OFF)
 add_subdirectory(deps/leveldb-1.23)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
-set(CMAKE_CXX_FLAGS -std=c++11)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+include(c++-standards)
+include(compiler-options)
+include(link-time-optimization)
+include(sanitizers)
+
+# Require C++ 11
+cxx_11()
+
+# enable LTO/IPO for all targets. Doesn't work with GCC.
+link_time_optimization()
+
 
 add_definitions(
   -D_GNU_SOURCE

--- a/cmake/c++-standards.cmake
+++ b/cmake/c++-standards.cmake
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2018-2021 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Set the compiler standard to C++11
+macro(cxx_11)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  if(MSVC_VERSION GREATER_EQUAL "1900" AND CMAKE_VERSION LESS 3.10)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("/std:c++11" _cpp_latest_flag_supported)
+    if(_cpp_latest_flag_supported)
+      add_compile_options("/std:c++11")
+    endif()
+  endif()
+endmacro()
+
+# Set the compiler standard to C++14
+macro(cxx_14)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  if(MSVC_VERSION GREATER_EQUAL "1900" AND CMAKE_VERSION LESS 3.10)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("/std:c++14" _cpp_latest_flag_supported)
+    if(_cpp_latest_flag_supported)
+      add_compile_options("/std:c++14")
+    endif()
+  endif()
+endmacro()
+
+# Set the compiler standard to C++17
+macro(cxx_17)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  if(MSVC_VERSION GREATER_EQUAL "1900" AND CMAKE_VERSION LESS 3.10)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("/std:c++17" _cpp_latest_flag_supported)
+    if(_cpp_latest_flag_supported)
+      add_compile_options("/std:c++17")
+    endif()
+  endif()
+endmacro()
+
+# Set the compiler standard to C++20
+macro(cxx_20)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endmacro()
+
+# Set the compiler standard to C++23
+macro(cxx_23)
+  set(CMAKE_CXX_STANDARD 23)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endmacro()

--- a/cmake/compiler-options.cmake
+++ b/cmake/compiler-options.cmake
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+option(ENABLE_ALL_WARNINGS "Compile with all warnings for the major compilers"
+       OFF)
+option(ENABLE_EFFECTIVE_CXX "Enable Effective C++ warnings" OFF)
+option(GENERATE_DEPENDENCY_DATA "Generates .d files with header dependencies"
+       OFF)
+
+if(ENABLE_ALL_WARNINGS)
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+    # GCC/Clang
+    add_compile_options(-Wall -Wextra)
+  elseif(MSVC)
+    # MSVC
+    add_compile_options(/W4)
+  endif()
+endif()
+
+if(ENABLE_EFFECTIVE_CXX)
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")
+  endif()
+endif()
+
+if(GENERATE_DEPENDENCY_DATA)
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+     OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+    add_compile_options(-MD)
+  else()
+    message(
+      WARNING "Cannot generate header dependency on non GCC/Clang compilers.")
+  endif()
+endif()

--- a/cmake/link-time-optimization.cmake
+++ b/cmake/link-time-optimization.cmake
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2021 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+include(CheckIPOSupported)
+
+# Checks for, and enables IPO/LTO for all following targets
+#
+# Running with GCC seems to have no effect
+# ~~~
+# Optional:
+# REQUIRED - If this is passed in, CMake configuration will fail with an error if LTO/IPO is not supported
+# ~~~
+macro(link_time_optimization)
+  # Argument parsing
+  set(options REQUIRED)
+  set(single_value_keywords)
+  set(multi_value_keywords)
+  cmake_parse_arguments(
+    link_time_optimization "${options}" "${single_value_keywords}"
+    "${multi_value_keywords}" ${ARGN})
+
+  check_ipo_supported(RESULT result OUTPUT output)
+  if(result)
+    # It's available, set it for all following items
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  else()
+    if(link_time_optimization_REQUIRED)
+      message(
+        FATAL_ERROR
+          "Link Time Optimization not supported, but listed as REQUIRED: ${output}"
+      )
+    else()
+      message(WARNING "Link Time Optimization not supported: ${output}")
+    endif()
+  endif()
+endmacro()
+
+# Checks for, and enables IPO/LTO for the specified target
+#
+# Running with GCC seems to have no effect
+# ~~~
+# Required:
+# TARGET_NAME - Name of the target to generate code coverage for
+# Optional:
+# REQUIRED - If this is passed in, CMake configuration will fail with an error if LTO/IPO is not supported
+# ~~~
+function(target_link_time_optimization TARGET_NAME)
+  # Argument parsing
+  set(options REQUIRED)
+  set(single_value_keywords)
+  set(multi_value_keywords)
+  cmake_parse_arguments(
+    target_link_time_optimization "${options}" "${single_value_keywords}"
+    "${multi_value_keywords}" ${ARGN})
+
+  check_ipo_supported(RESULT result OUTPUT output)
+  if(result)
+    # It's available, set it for all following items
+    set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION
+                                                TRUE)
+  else()
+    if(target_link_time_optimization_REQUIRED)
+      message(
+        FATAL_ERROR
+          "Link Time Optimization not supported, but listed as REQUIRED for the ${TARGET_NAME} target: ${output}"
+      )
+    else()
+      message(WARNING "Link Time Optimization not supported: ${output}")
+    endif()
+  endif()
+endfunction()

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,151 @@
+#
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+include(CheckCXXSourceCompiles)
+
+set(USE_SANITIZER
+    ""
+    CACHE
+      STRING
+      "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'"
+)
+
+function(append value)
+  foreach(variable ${ARGN})
+    set(${variable}
+        "${${variable}} ${value}"
+        PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
+function(test_san_flags return_var flags)
+    set(QUIET_BACKUP ${CMAKE_REQUIRED_QUIET})
+    set(CMAKE_REQUIRED_QUIET TRUE)
+    unset(${return_var} CACHE)
+    set(FLAGS_BACKUP ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${flags}")
+    check_cxx_source_compiles("int main() { return 0; }" ${return_var})
+    set(CMAKE_REQUIRED_FLAGS "${FLAGS_BACKUP}")
+    set(CMAKE_REQUIRED_QUIET "${QUIET_BACKUP}")
+endfunction()
+
+if(USE_SANITIZER)
+  append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+  unset(SANITIZER_SELECTED_FLAGS)
+
+  if(UNIX)
+
+    if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+      append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Aa]ddress)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
+      message(STATUS "Testing with Address sanitizer")
+      set(SANITIZER_ADDR_FLAG "-fsanitize=address")
+      test_san_flags(SANITIZER_ADDR_AVAILABLE ${SANITIZER_ADDR_FLAG})
+      if (SANITIZER_ADDR_AVAILABLE)
+        message(STATUS "  Building with Address sanitizer")
+        append("${SANITIZER_ADDR_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Address sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
+      set(SANITIZER_MEM_FLAG "-fsanitize=memory")
+      if(USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+        message(STATUS "Testing with MemoryWithOrigins sanitizer")
+        append("-fsanitize-memory-track-origins" SANITIZER_MEM_FLAG)
+      else()
+        message(STATUS "Testing with Memory sanitizer")
+      endif()
+      test_san_flags(SANITIZER_MEM_AVAILABLE ${SANITIZER_MEM_FLAG})
+      if (SANITIZER_MEM_AVAILABLE)
+        if(USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+            message(STATUS "  Building with MemoryWithOrigins sanitizer")
+        else()
+            message(STATUS "  Building with Memory sanitizer")
+        endif()
+        append("${SANITIZER_MEM_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Memory [With Origins] sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Uu]ndefined)")
+      message(STATUS "Testing with Undefined Behaviour sanitizer")
+      set(SANITIZER_UB_FLAG "-fsanitize=undefined")
+      if(EXISTS "${BLACKLIST_FILE}")
+        append("-fsanitize-blacklist=${BLACKLIST_FILE}" SANITIZER_UB_FLAG)
+      endif()
+      test_san_flags(SANITIZER_UB_AVAILABLE ${SANITIZER_UB_FLAG})
+      if (SANITIZER_UB_AVAILABLE)
+        message(STATUS "  Building with Undefined Behaviour sanitizer")
+        append("${SANITIZER_UB_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Undefined Behaviour sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Tt]hread)")
+      message(STATUS "Testing with Thread sanitizer")
+      set(SANITIZER_THREAD_FLAG "-fsanitize=thread")
+      test_san_flags(SANITIZER_THREAD_AVAILABLE ${SANITIZER_THREAD_FLAG})
+      if (SANITIZER_THREAD_AVAILABLE)
+        message(STATUS "  Building with Thread sanitizer")
+        append("${SANITIZER_THREAD_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Ll]eak)")
+      message(STATUS "Testing with Leak sanitizer")
+      set(SANITIZER_LEAK_FLAG "-fsanitize=leak")
+      test_san_flags(SANITIZER_LEAK_AVAILABLE ${SANITIZER_LEAK_FLAG})
+      if (SANITIZER_LEAK_AVAILABLE)
+        message(STATUS "  Building with Leak sanitizer")
+        append("${SANITIZER_LEAK_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    message(STATUS "Sanitizer flags: ${SANITIZER_SELECTED_FLAGS}")
+    test_san_flags(SANITIZER_SELECTED_COMPATIBLE ${SANITIZER_SELECTED_FLAGS})
+    if (SANITIZER_SELECTED_COMPATIBLE)
+      message(STATUS " Building with ${SANITIZER_SELECTED_FLAGS}")
+      append("${SANITIZER_SELECTED_FLAGS}" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(FATAL_ERROR " Sanitizer flags ${SANITIZER_SELECTED_FLAGS} are not compatible.")
+    endif()
+  elseif(MSVC)
+    if(USE_SANITIZER MATCHES "([Aa]ddress)")
+      message(STATUS "Building with Address sanitizer")
+      append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(
+        FATAL_ERROR
+          "This sanitizer not yet supported in the MSVC environment: ${USE_SANITIZER}"
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "USE_SANITIZER is not supported on this platform.")
+  endif()
+
+endif()


### PR DESCRIPTION
- Bumped CMake minimum required version to `3.10`
- Added cmake modules (details) below
- enforced `C++ 11` version requirement
- enabled LTO/IPO (which will work when compiled using clang)
- added enabling sanitizers (Address, Memory, MemoryWithOrigins, Thread, Undefined , Leak) support (details below)
- added compile time options support 

## C++ Standards [`cmake/c++-standards.cmake`](./cmake/c++-standards.cmake)

Using the functions `cxx_11()`, `cxx_14()`, `cxx_17()` or `cxx_20()` this adds the appropriate flags for both unix and MSVC compilers, even for those before 3.11 with improper support.

These obviously force the standard to be required, and also disables compiler-specific extensions, ie `--std=gnu++11`. This helps to prevent fragmenting the code base with items not available elsewhere, adhering to the agreed C++ standards only.

## Link Time Optimization / Interprocedural Optimization [`cmake/link-time-optimization.cmake`](./cmake/link-time-optimization.cmake)

There are two callable objects here, `link_time_optimization` which applies LTO/IPO for all following targets, and `target_link_time_optimization` which applies it to a specified target.

Doesn't work with GCC.

### Optional Arguments

#### REQUIRED
If this is passed in, CMake configuration will fail with an error if LTO/IPO is not supported

## Compiler Options [`cmake/compiler-options.cmake`](./cmake/compiler-options.cmake)

Allows for easy use of some pre-made compiler options for the major compilers.

Using `-DENABLE_ALL_WARNINGS=ON` will enable almost all of the warnings available for a compiler:

| Compiler | Options       |
| :------- | :------------ |
| MSVC     | /W4           |
| GCC      | -Wall -Wextra |
| Clang    | -Wall -Wextra |

Using `-DENABLE_EFFECTIVE_CXX=ON` adds the `-Weffc++` for both GCC and clang.

Using `-DGENERATE_DEPENDENCY_DATA=ON` generates `.d` files along with regular object files on a per-source file basis on GCC/Clang compilers. These files contains the list of all header files used during compilation of that compilation unit.

## Sanitizer Builds [`cmake/sanitizers.cmake`](./cmake/sanitizers.cmake)

Sanitizers are tools that perform checks during a program’s runtime and returns issues, and as such, along with unit testing, code coverage and static analysis, is another tool to add to the programmers toolbox. And of course, like the previous tools, are tragically simple to add into any project using CMake, allowing any project and developer to quickly and easily use.

A quick rundown of the tools available, and what they do:
- [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) detects memory leaks, or issues where memory is allocated and never deallocated, causing programs to slowly consume more and more memory, eventually leading to a crash.
- [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) is a fast memory error detector. It is useful for detecting most issues dealing with memory, such as:
    - Out of bounds accesses to heap, stack, global
    - Use after free
    - Use after return
    - Use after scope
    - Double-free, invalid free
    - Memory leaks (using LeakSanitizer)
- [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) detects data races for multi-threaded code.
- [UndefinedBehaviourSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) detects the use of various features of C/C++ that are explicitly listed as resulting in undefined behavior. Most notably:
    - Using misaligned or null pointer.
    - Signed integer overflow
    - Conversion to, from, or between floating-point types which would overflow the destination
    - Division by zero
    - Unreachable code
- [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) detects uninitialized reads.

These are used by declaring the `USE_SANITIZER` CMake variable as string containing any of:
- Address
- Memory
- MemoryWithOrigins
- Undefined
- Thread
- Leak

Multiple values are allowed, e.g. `-DUSE_SANITIZER=Address,Leak` but some sanitizers cannot be combined together, e.g.`-DUSE_SANITIZER=Address,Memory` will result in configuration error. The delimeter character is not required and `-DUSE_SANITIZER=AddressLeak` would work as well.
