### PR TITLE
Added compressHTTP & compressMessage filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_executable(pipy
   src/fetch.cpp
   src/file.cpp
   src/filter.cpp
+  src/filters/compress-message.cpp
   src/filters/connect.cpp
   src/filters/decompress-message.cpp
   src/filters/deframe.cpp

--- a/docs/reference/api/Configuration/compressHTTP.mdx
+++ b/docs/reference/api/Configuration/compressHTTP.mdx
@@ -23,7 +23,7 @@ This filter checks _head.headers['content-encoding']_ of the input [MessageStart
 
 There are options you can use in the _options_ parameter to configure compression method, compression level:
 
-- _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
+- _enabled_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
 - _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
 - _level_  - Compression level settings. It need to be one of `default`, `none`, `speed`, `best`. default is _default_.
 
@@ -34,7 +34,7 @@ There are options you can use in the _options_ parameter to configure compressio
 pipy()
   .pipeline('example')
     .compressHTTP({
-      enable : true,
+      enabled : true,
       method : 'gzip',
       level  : 'default'
     })

--- a/docs/reference/api/Configuration/compressHTTP.mdx
+++ b/docs/reference/api/Configuration/compressHTTP.mdx
@@ -17,7 +17,7 @@ A **compressHTTP** filter compresses the bodies of HTTP [Messages](/reference/ap
 | ↓                | **Message** |
 | _Output_         |             |
 
-This filter checks _head.headers['content-encoding']_ of the input [MessageStart](/reference/api/MessageStart) event. If its value is not set or its value is not of selected compression method, the message body will be compressed in the output.
+This filter checks _head.headers['content-encoding']_ of the input [MessageStart](/reference/api/MessageStart) event. If its value is not set or its value is different with selected compression method, the message body will be compressed with selected compression method in the output.
 
 ### Options
 
@@ -25,7 +25,7 @@ There are options you can use in the _options_ parameter to configure compressio
 
 - _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
 - _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
-- _level_  - Compression level settings. It need to be one of `default`, `no`, `speed`, `best`. default is _default_.
+- _level_  - Compression level settings. It need to be one of `default`, `none`, `speed`, `best`. default is _default_.
 
 
 ## Syntax
@@ -34,11 +34,10 @@ There are options you can use in the _options_ parameter to configure compressio
 pipy()
   .pipeline('example')
     .compressHTTP({
-      "enable" : true,
-      "method" : "gzip",
-      "level"  : "default"
+      enable : true,
+      method : 'gzip',
+      level  : 'default'
     })
-
 ```
 
 ### Parameters

--- a/docs/reference/api/Configuration/compressHTTP.mdx
+++ b/docs/reference/api/Configuration/compressHTTP.mdx
@@ -1,0 +1,55 @@
+---
+title: "Configuration.compressHTTP()"
+api: Configuration.compressHTTP()
+---
+
+## Description
+
+Appends a **compressHTTP** filter to the current pipeline layout.
+
+A **compressHTTP** filter compresses the bodies of HTTP [Messages](/reference/api/Message). Its input and output are both _Messages_.
+
+|                  |             |
+|:----------------:|:-----------:|
+| _Input_          |             |
+| ↓                | **Message** |
+| `compressHTTP` |             |
+| ↓                | **Message** |
+| _Output_         |             |
+
+This filter checks _head.headers['content-encoding']_ of the input [MessageStart](/reference/api/MessageStart) event. If its value is not set or its value is not of selected compression method, the message body will be compressed in the output.
+
+### Options
+
+There are options you can use in the _options_ parameter to configure compression method, compression level:
+
+- _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
+- _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
+- _level_  - Compression level settings. It need to be one of `default`, `no`, `speed`, `best`. default is _default_.
+
+
+## Syntax
+
+``` js
+pipy()
+  .pipeline('example')
+    .compressHTTP({
+      "enable" : true,
+      "method" : "gzip",
+      "level"  : "default"
+    })
+
+```
+
+### Parameters
+
+<Parameters/>
+
+### Return value
+
+<ReturnValue/>
+
+## See Also
+
+* [Configuration](/reference/api/Configuration)
+* [compressMessage()](/reference/api/Configuration/compressMessage)

--- a/docs/reference/api/Configuration/compresssMessage.mdx
+++ b/docs/reference/api/Configuration/compresssMessage.mdx
@@ -25,17 +25,17 @@ There are options you can use in the _options_ parameter to configure compressio
 
 - _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
 - _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
-- _level_  - Compression level settings. It need to be one of `default`, `no`, `speed`, `best`. default is _default_.
+- _level_  - Compression level settings. It need to be one of `default`, `none`, `speed`, `best`. default is _default_.
 
 ## Syntax
 
 ``` js
 pipy()
   .pipeline('example')
-    .compressMessage(
-      "enable" : true,
-      "method" : "gzip",
-      "level"  : "default"
+    .compressMessage({
+      enable : true,
+      method : 'gzip',
+      level  : 'default'
     })
 ```
 

--- a/docs/reference/api/Configuration/compresssMessage.mdx
+++ b/docs/reference/api/Configuration/compresssMessage.mdx
@@ -1,0 +1,53 @@
+---
+title: "Configuration.compressMessage()"
+api: Configuration.compressMessage()
+---
+
+## Description
+
+Appends a **compressMessage** filter to the current pipeline layout.
+
+A **compressMessage** filter compresses the bodies of [Messages](/reference/api/Message). Its input and output are both _Messages_.
+
+|                     |             |
+|:-------------------:|:-----------:|
+| _Input_             |             |
+| ↓                   | **Message** |
+| `compressMessage` |             |
+| ↓                   | **Message** |
+| _Output_            |             |
+
+The method, compression level used for compression are specified by the _options_ parameter. Currently supported compression methods are _deflate_, _gzip_.
+
+### Options
+
+There are options you can use in the _options_ parameter to configure compression method, compression level:
+
+- _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
+- _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
+- _level_  - Compression level settings. It need to be one of `default`, `no`, `speed`, `best`. default is _default_.
+
+## Syntax
+
+``` js
+pipy()
+  .pipeline('example')
+    .compressMessage(
+      "enable" : true,
+      "method" : "gzip",
+      "level"  : "default"
+    })
+```
+
+### Parameters
+
+<Parameters/>
+
+### Return value
+
+<ReturnValue/>
+
+## See Also
+
+* [Configuration](/reference/api/Configuration)
+* [compressHTTP()](/reference/api/Configuration/compressHTTP)

--- a/docs/reference/api/Configuration/compresssMessage.mdx
+++ b/docs/reference/api/Configuration/compresssMessage.mdx
@@ -23,7 +23,7 @@ The method, compression level used for compression are specified by the _options
 
 There are options you can use in the _options_ parameter to configure compression method, compression level:
 
-- _enable_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
+- _enabled_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
 - _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
 - _level_  - Compression level settings. It need to be one of `default`, `none`, `speed`, `best`. default is _default_.
 
@@ -33,7 +33,7 @@ There are options you can use in the _options_ parameter to configure compressio
 pipy()
   .pipeline('example')
     .compressMessage({
-      enable : true,
+      enabled : true,
       method : 'gzip',
       level  : 'default'
     })

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -37,6 +37,7 @@
 
 // all filters
 #include "filters/connect.hpp"
+#include "filters/compress-message.hpp"
 #include "filters/decompress-message.hpp"
 #include "filters/deframe.hpp"
 #include "filters/demux.hpp"
@@ -180,6 +181,14 @@ void Configuration::accept_tls(pjs::Str *target, pjs::Object *options) {
   auto *filter = new tls::Server(options);
   filter->add_sub_pipeline(target);
   append_filter(filter);
+}
+
+void Configuration::compress_message(pjs::Object *options) {
+  append_filter(new CompressMessage(CompressMessageBase::Options::parse(options)));
+}
+
+void Configuration::compress_http(pjs::Object *options) {
+  append_filter(new CompressHTTP(CompressMessageBase::Options::parse(options)));
 }
 
 void Configuration::connect(const pjs::Value &target, pjs::Object *options) {
@@ -762,6 +771,30 @@ template<> void ClassDef<Configuration>::init() {
     } catch (std::runtime_error &err) {
       ctx.error(err);
     }
+  });
+
+  // Configuration.compressHTTP
+  method("compressHTTP", [](Context &ctx, Object *thiz, Value &result) {
+      Object *options = nullptr;
+      if (!ctx.arguments(0, &options)) return;
+      try {
+        thiz->as<Configuration>()->compress_http(options);
+        result.set(thiz);
+      } catch (std::runtime_error &err) {
+        ctx.error(err);
+      }
+  });
+
+  // Configuration.compressMessage
+  method("compressMessage", [](Context &ctx, Object *thiz, Value &result) {
+      Object *options = nullptr;
+      if (!ctx.arguments(0, &options)) return;
+      try {
+        thiz->as<Configuration>()->compress_message(options);
+        result.set(thiz);
+      } catch (std::runtime_error &err) {
+        ctx.error(err);
+      }
   });
 
   // Configuration.connect

--- a/src/api/configuration.hpp
+++ b/src/api/configuration.hpp
@@ -71,6 +71,8 @@ public:
   void accept_http_tunnel(pjs::Str *target, pjs::Function *handler);
   void accept_socks(pjs::Str *target, pjs::Function *on_connect);
   void accept_tls(pjs::Str *target, pjs::Object *options);
+  void compress_http(pjs::Object *options);
+  void compress_message(pjs::Object *options);
   void connect(const pjs::Value &target, pjs::Object *options);
   void connect_http_tunnel(pjs::Str *target, const pjs::Value &address);
   void connect_socks(pjs::Str *target, const pjs::Value &address);

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -93,6 +93,80 @@ private:
 };
 
 //
+// Deflate
+//
+
+class Deflate : public pjs::Pooled<Deflate>, public Compressor {
+public:
+  enum class CompressionMethod {
+      deflate = MAX_WBITS,
+      gzip = 16 + MAX_WBITS,
+  };
+
+  Deflate(const std::function<void(Data*)> &in, CompressionMethod method = CompressionMethod::gzip, int level = Z_DEFAULT_COMPRESSION)
+    : m_in(in)
+    , m_method(method)
+  {
+    m_zs.zalloc = Z_NULL;
+    m_zs.zfree = Z_NULL;
+    m_zs.opaque = Z_NULL;
+    m_zs.next_in = Z_NULL;
+    m_zs.avail_out = 0;
+    auto ret = deflateInit2(&m_zs, level, Z_DEFLATED, static_cast<int>(method), 8, Z_DEFAULT_STRATEGY);
+
+    if (ret != Z_OK) {
+      throw std::runtime_error("[compress] zlib init failed");
+    }
+  }
+
+private:
+  const std::function<void(Data*)> m_in;
+  z_stream m_zs;
+  CompressionMethod m_method;
+
+  ~Deflate(){
+    deflateEnd(&m_zs);
+  }
+
+  virtual bool process(const Data *data) override {
+    static Data::Producer s_dp(m_method == CompressionMethod::deflate ? "deflate" : "gzip");
+
+    auto len = data->size();
+    unsigned char buf[DATA_CHUNK_SIZE];
+    pjs::Ref<Data> output_data(Data::make());
+
+    for (const auto chk : data->chunks()) {
+      m_zs.next_in = (const unsigned char*)std::get<0>(chk);
+      m_zs.avail_in = std::get<1>(chk);
+      len -= m_zs.avail_in;
+      auto flush = len ? Z_NO_FLUSH : Z_FINISH;
+      do {
+        m_zs.avail_out = DATA_CHUNK_SIZE;
+        m_zs.next_out = buf;
+
+        auto ret = ::deflate(&m_zs, flush);
+        if (ret == Z_STREAM_ERROR) {
+          deflateEnd(&m_zs);
+          return false;
+        }
+        if (auto size = DATA_CHUNK_SIZE - m_zs.avail_out) {
+          s_dp.push(output_data, buf, size);
+        }
+      } while (m_zs.avail_out == 0);
+    }
+    if (m_zs.avail_in != 0) {
+      throw std::runtime_error("[compress] not all input used.");
+    }
+    m_in(output_data);
+    return true;
+  }
+
+  virtual bool end() override {
+    delete this;
+    return true;
+  }
+};
+//
 // Decompressor
 //
 
@@ -100,4 +174,20 @@ Decompressor* Decompressor::inflate(const std::function<void(Data*)> &out) {
   return new Inflate(out);
 }
 
+
+//
+// Decompressor
+//
+
+Compressor *Compressor::deflate(const std::function<void(Data *)> &in, int compression_level) {
+    return new Deflate(in,Deflate::CompressionMethod::deflate, compression_level);
+}
+
+Compressor *Compressor::gzip(const std::function<void(Data *)> &in, int compression_level) {
+  return new Deflate(in,Deflate::CompressionMethod::gzip, compression_level);
+}
+
+Compressor *Compressor::brotli(const std::function<void(Data *)> &in, int compression_level) {
+  throw std::runtime_error("Brotli compression not implemented");
+}
 } // namespace pipy

--- a/src/compress.hpp
+++ b/src/compress.hpp
@@ -47,6 +47,23 @@ protected:
   ~Decompressor() {}
 };
 
+//
+// Compressor
+//
+
+class Compressor {
+public:
+
+  static Compressor* deflate(const std::function<void(Data*)> &in, int compression_level);
+  static Compressor* gzip(const std::function<void(Data*)> &in, int compression_level);
+  static Compressor* brotli(const std::function<void(Data*)> &in, int compression_level);
+
+  virtual bool process(const Data *data) = 0;
+  virtual bool end() = 0;
+
+protected:
+  ~Compressor() {}
+};
 } // namespace pipy
 
 #endif // COMPRESS_HPP

--- a/src/filters/compress-message.cpp
+++ b/src/filters/compress-message.cpp
@@ -1,0 +1,239 @@
+/*
+ *  Copyright (c) 2019 by flomesh.io
+ *
+ *  Unless prior written consent has been obtained from the copyright
+ *  owner, the following shall not be allowed.
+ *
+ *  1. The distribution of any source codes, header files, make files,
+ *     or libraries of the software.
+ *
+ *  2. Disclosure of any source codes pertaining to the software to any
+ *     additional parties.
+ *
+ *  3. Alteration or removal of any notices in or on the software or
+ *     within the documentation included within the software.
+ *
+ *  ALL SOURCE CODE AS WELL AS ALL DOCUMENTATION INCLUDED WITH THIS
+ *  SOFTWARE IS PROVIDED IN AN “AS IS” CONDITION, WITHOUT WARRANTY OF ANY
+ *  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "compress-message.hpp"
+#include "compress.hpp"
+#include "data.hpp"
+#include "logging.hpp"
+
+namespace pipy {
+
+//
+// CompressMessageBase
+//
+
+CompressMessageBase::CompressMessageBase(const Options &options)
+  : m_options(options)
+{
+}
+
+CompressMessageBase::CompressMessageBase(const CompressMessageBase &r)
+  : Filter(r)
+  , m_options(r.m_options)
+{
+}
+
+void CompressMessageBase::reset() {
+  Filter::reset();
+  if (m_compressor) {
+    m_compressor->end();
+    m_compressor = nullptr;
+  }
+  m_message_started = false;
+}
+
+void CompressMessageBase::process(Event *evt) {
+  if (auto *data = evt->as<Data>()) {
+    if (m_message_started) {
+      if (m_compressor) {
+        if (!m_compressor->process(data)) {
+          Log::warn("[compress] compression error");
+          m_compressor->end();
+          m_compressor = nullptr;
+        }
+      } else {
+        output(evt);
+      }
+    }
+    return;
+  }
+
+  if (auto start = evt->as<MessageStart>()) {
+    if (!m_message_started) {
+      m_compressor = new_compressor(
+        start,
+        [this](Data *data) {
+          output(data);
+        }
+      );
+      m_message_started = true;
+    }
+
+  } else if (evt->is<MessageEnd>()) {
+    if (m_compressor) {
+      m_compressor->end();
+      m_compressor = nullptr;
+    }
+    m_message_started = false;
+  }
+
+  output(evt);
+}
+
+static const pjs::Ref<pjs::Str> s_headers(pjs::Str::make("headers"));
+static const pjs::Ref<pjs::Str> s_content_encoding(pjs::Str::make("content-encoding"));
+static const pjs::Ref<pjs::Str> s_gzip(pjs::Str::make("gzip"));
+static const pjs::Ref<pjs::Str> s_deflate(pjs::Str::make("deflate"));
+static const pjs::Ref<pjs::Str> s_brtoli(pjs::Str::make("brotli"));
+
+auto CompressMessageBase::new_compressor(
+        MessageStart *start,
+        const std::function<void(Data *)> &in
+) -> Compressor * {
+  if (!m_options.enable) return nullptr;
+
+  auto head = start->head();
+  if (!head) return nullptr;
+
+  pjs::Ref<pjs::Str> method = m_options.algo == CompressionMethod::deflate ? s_deflate : (
+          m_options.algo == CompressionMethod::gzip ? s_gzip : s_brtoli);
+  pjs::Value headers;
+  head->get(s_headers, headers);
+  if (!headers.is_object() || !headers.o()) return nullptr;
+
+  pjs::Value content_encoding;
+  headers.o()->get(s_content_encoding, content_encoding);
+  if ((!content_encoding.is_string()) || (content_encoding.s() != method)) {
+    headers.o()->set(s_content_encoding, method.get());
+  }
+
+  switch (m_options.algo) {
+    case CompressionMethod::deflate:
+      return Compressor::deflate(in, static_cast<int>(m_options.level) - 1);
+    case CompressionMethod::gzip:
+      return Compressor::gzip(in, static_cast<int>(m_options.level) - 1);
+    case CompressionMethod::brotli:
+      return Compressor::brotli(in, static_cast<int>(m_options.level) - 1);
+    default:
+      Log::error("[compress] unknown compression algorithm: %s", m_options.algo);
+      return nullptr;
+  }
+}
+
+//
+// CompressMessageBase::Options
+
+CompressMessageBase::Options CompressMessageBase::Options::parse(pjs::Object *options) {
+  CompressMessageBase::Options opts;
+  if (options) {
+    pjs::Value enable, method, level;
+    options->get("enable", enable);
+    if (!enable.is_undefined()) {
+      if (!enable.is_boolean()) throw std::runtime_error("options.enable expects a boolean");
+      opts.enable = enable.b();
+    }
+    options->get("method", method);
+    if (!method.is_undefined()) {
+      if (!method.is_string()) throw std::runtime_error("options.method requires a string");
+      auto algo_type = pjs::EnumDef<CompressMessage::CompressionMethod>::value(method.s());
+      if (int(algo_type) < 0)
+        throw std::runtime_error("invalid options.method. It need to be one of [deflate | gzip | brotli]");
+      opts.algo = algo_type;
+    }
+    options->get("level", level);
+    if (!level.is_undefined()) {
+      if (!level.is_string()) throw std::runtime_error("options.level requires a string");
+      auto comp_level = pjs::EnumDef<CompressMessage::CompressionLevel>::value(level.s());
+      if (int(comp_level) < 0)
+        throw std::runtime_error("invalid options.level. It need to be one of [default | no | speed | best]");
+      opts.level = comp_level;
+    }
+  }
+  return opts;
+}
+
+//
+// CompressMessage
+//
+
+CompressMessage::CompressMessage(const Options &options)
+  : CompressMessageBase(options)
+{
+}
+
+CompressMessage::CompressMessage(const CompressMessage &r)
+  : CompressMessageBase(r)
+{
+}
+
+CompressMessage::~CompressMessage()
+{
+}
+
+void CompressMessage::dump(std::ostream &out) {
+  out << "compressMessage";
+}
+
+auto CompressMessage::clone() -> Filter * {
+  return new CompressMessage(*this);
+}
+
+//
+// CompressHTTP
+//
+
+CompressHTTP::CompressHTTP(const Options &options)
+  : CompressMessageBase(options)
+{
+}
+
+CompressHTTP::CompressHTTP(const CompressHTTP &r)
+  : CompressMessageBase(r)
+{
+}
+
+CompressHTTP::~CompressHTTP() {
+}
+
+void CompressHTTP::dump(std::ostream &out) {
+  out << "compressHTTP";
+}
+
+auto CompressHTTP::clone() -> Filter * {
+  return new CompressHTTP(*this);
+}
+} // namespace pipy
+
+//
+// Algorithm
+//
+namespace pjs {
+  using namespace pipy;
+
+  template<>
+  void EnumDef<CompressMessageBase::CompressionMethod>::init() {
+    define(CompressMessageBase::CompressionMethod::deflate, "deflate");
+    define(CompressMessageBase::CompressionMethod::gzip, "gzip");
+    define(CompressMessageBase::CompressionMethod::brotli, "brotli");
+  }
+
+  template<>
+  void EnumDef<CompressMessageBase::CompressionLevel>::init() {
+    define(CompressMessageBase::CompressionLevel::Default, "default");
+    define(CompressMessageBase::CompressionLevel::No, "no");
+    define(CompressMessageBase::CompressionLevel::Speed, "speed");
+    define(CompressMessageBase::CompressionLevel::Best, "best");
+  }
+}

--- a/src/filters/compress-message.cpp
+++ b/src/filters/compress-message.cpp
@@ -139,7 +139,7 @@ CompressMessageBase::Options CompressMessageBase::Options::parse(pjs::Object *op
   CompressMessageBase::Options opts;
   if (options) {
     pjs::Value enable, method, level;
-    options->get("enable", enable);
+    options->get("enabled", enable);
     if (!enable.is_undefined()) {
       if (!enable.is_boolean()) throw std::runtime_error("options.enable expects a boolean");
       opts.enable = enable.b();

--- a/src/filters/compress-message.cpp
+++ b/src/filters/compress-message.cpp
@@ -157,7 +157,7 @@ CompressMessageBase::Options CompressMessageBase::Options::parse(pjs::Object *op
       if (!level.is_string()) throw std::runtime_error("options.level requires a string");
       auto comp_level = pjs::EnumDef<CompressMessage::CompressionLevel>::value(level.s());
       if (int(comp_level) < 0)
-        throw std::runtime_error("invalid options.level. It need to be one of [default | no | speed | best]");
+        throw std::runtime_error("invalid options.level. It need to be one of [default | none | speed | best]");
       opts.level = comp_level;
     }
   }
@@ -232,7 +232,7 @@ namespace pjs {
   template<>
   void EnumDef<CompressMessageBase::CompressionLevel>::init() {
     define(CompressMessageBase::CompressionLevel::Default, "default");
-    define(CompressMessageBase::CompressionLevel::No, "no");
+    define(CompressMessageBase::CompressionLevel::None, "none");
     define(CompressMessageBase::CompressionLevel::Speed, "speed");
     define(CompressMessageBase::CompressionLevel::Best, "best");
   }

--- a/src/filters/compress-message.hpp
+++ b/src/filters/compress-message.hpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2019 by flomesh.io
+ *
+ *  Unless prior written consent has been obtained from the copyright
+ *  owner, the following shall not be allowed.
+ *
+ *  1. The distribution of any source codes, header files, make files,
+ *     or libraries of the software.
+ *
+ *  2. Disclosure of any source codes pertaining to the software to any
+ *     additional parties.
+ *
+ *  3. Alteration or removal of any notices in or on the software or
+ *     within the documentation included within the software.
+ *
+ *  ALL SOURCE CODE AS WELL AS ALL DOCUMENTATION INCLUDED WITH THIS
+ *  SOFTWARE IS PROVIDED IN AN “AS IS” CONDITION, WITHOUT WARRANTY OF ANY
+ *  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef COMPRESS_MESSAGE_HPP
+#define COMPRESS_MESSAGE_HPP
+
+#include "filter.hpp"
+
+namespace pipy {
+
+class Compressor;
+class Data;
+
+//
+// CompressMessageBase
+//
+
+class CompressMessageBase : public Filter {
+public:
+    enum class CompressionMethod {
+        deflate,
+        gzip,
+        brotli,
+    };
+
+    enum class CompressionLevel {
+        Default,
+        No,
+        Speed,
+        Best = 10,
+    };
+
+    struct Options {
+        bool enable = true;
+        CompressionMethod algo = CompressionMethod::gzip;
+        CompressionLevel level = CompressionLevel::Default;
+
+        static Options parse(pjs::Object *options);
+    };
+protected:
+  CompressMessageBase(const Options &options);
+  CompressMessageBase(const CompressMessageBase &r);
+
+  virtual auto new_compressor(
+    MessageStart *start,
+    const std::function<void(Data*)> &in
+    ) -> Compressor*;
+
+private:
+  virtual void reset() override;
+  virtual void process(Event *evt) override;
+
+  Compressor* m_compressor = nullptr;
+  bool m_message_started = false;
+  Options m_options;
+};
+
+//
+// CompressMessage
+//
+
+class CompressMessage : public CompressMessageBase {
+public:
+  CompressMessage(const Options &options);
+
+private:
+  CompressMessage(const CompressMessage &r);
+  ~CompressMessage();
+
+  virtual auto clone() -> Filter* override;
+  virtual void dump(std::ostream &out) override;
+};
+
+//
+// CompressHTTP
+//
+
+class CompressHTTP : public CompressMessageBase {
+public:
+  CompressHTTP(const Options &options);
+
+private:
+  CompressHTTP(const CompressHTTP &r);
+  ~CompressHTTP();
+
+  virtual auto clone() -> Filter* override;
+  virtual void dump(std::ostream &out) override;
+};
+
+} // namespace pipy
+
+#endif //COMPRESS_MESSAGE_HPP

--- a/src/filters/compress-message.hpp
+++ b/src/filters/compress-message.hpp
@@ -47,7 +47,7 @@ public:
 
     enum class CompressionLevel {
         Default,
-        No,
+        None,
         Speed,
         Best = 10,
     };


### PR DESCRIPTION
Added support for HTTP response compression and this PR adds two filters `compressHTTP` and `compressMessage`. Both of these filters are configurable via `options` object. Documentation for these two filters is added as well.

### Options

There are options you can use in the _options_ parameter to configure compression method, compression level:

- _enabled_ - Toggle compression mode. Boolean flag either `true` or `false`. default is _true_.
- _method_ - Compression method to use. It need to be one of `deflate`, `gzip`, and `brotli`. default is _gzip_.
- _level_  - Compression level settings. It need to be one of `default`, `none`, `speed`, `best`. default is _default_.
