### PR TITLE
[build] make cmake compatiable with loongnix-server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required (VERSION 3.13)
+if(PIPY_STATIC)
+  cmake_minimum_required (VERSION 3.13)
+else()
+  cmake_minimum_required (VERSION 3.10)
+endif()
+
 project(pipy)
 
 option(PIPY_GUI "include builtin GUI" ON)


### PR DESCRIPTION
The cmake version is 3.11 on loongnix-server 8, and no need to do static build on this distro at this stage.