### PR TITLE
[ci] move pipy-repo build to subsequent step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,45 +47,6 @@ jobs:
       release_version: ${{steps.version.outputs.release_version}}
       commit_date: ${{steps.version.outputs.commit_date}}
 
-  x86-pipy-repo:
-    needs: set-release-version
-    name: x86-pipy-repo
-    runs-on: ubuntu-latest
-    if: ${{ ! startsWith(needs.set-release-version.outputs.release_version, 'nightly') }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: pipy
-
-      - name: Setup buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Show envs
-        run: export
-
-      - name: Build image
-        id: build
-        env:
-          IMAGE: flomesh/pipy-repo
-          DOCKER_BUILDKIT: 1
-          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
-        run: |
-          ./build.sh -ncgp -t ${RELEASE_VERSION}
-          ls -l
-          echo "::set-output name=artifact_name::$(ls *${RELEASE_VERSION}*.tar.gz)"
-          echo "::set-output name=arch::$(uname -m)"
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          if-no-files-found: error
-          path: pipy/${{ steps.build.outputs.artifact_name }}
-          name: ${{ steps.build.outputs.artifact_name }}
-
-    outputs:
-      artifact_name: ${{steps.build.outputs.artifact_name}}
-      arch: ${{steps.build.outputs.arch}}
-
   x86-binary:
     needs: set-release-version
     name: x86-binary
@@ -295,28 +256,5 @@ jobs:
                   { "type": "binary", "arch": "${{needs.aarch64-binary.outputs.arch}}", "name": "${{ needs.aarch64-binary.outputs.artifact_name }}" },
                   { "type": "image", "arch": "${{needs.x86-alpine-docker.outputs.arch}}", "name": "${{ needs.x86-alpine-docker.outputs.artifact_name }}" },
                   { "type": "image", "arch": "${{needs.aarch64-alpine-docker.outputs.arch}}", "name": "${{ needs.aarch64-alpine-docker.outputs.artifact_name }}" }
-                ]
-             }
-
-  save-pipy-repo:
-    name: save pipy-repo
-    runs-on: ubuntu-latest
-    needs:
-      - set-release-version
-      - x86-pipy-repo
-      - save-log
-    steps:
-      - name: Save pipy-repo
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token:  ${{ secrets.REPO_DISPATCH_PAT }}
-          repository: ${{ secrets.REPO_FOR_LOG }}
-          event-type: repo-build
-          client-payload: |
-            {
-                "github": ${{toJSON(github)}},
-                "release_version": "${{needs.set-release-version.outputs.release_version}}",
-                "artifacts": [
-                  { "type": "image", "arch": "${{needs.x86-pipy-repo.outputs.arch}}", "name": "${{ needs.x86-pipy-repo.outputs.artifact_name }}" }
                 ]
              }


### PR DESCRIPTION
No need to build pipy-repo at this stage, and we move it to the steps after 'save log'