### PR TITLE
[docker] start multiple pipy instances based on docker cpu quota

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN rm -fr pipy/build \
 
 FROM alpine:3.14 as prod
 COPY --from=builder /pipy/bin/pipy /usr/local/bin/pipy
-COPY --from=builder /etc/pipy /etc/pipy
+COPY --from=builder /pipy/tutorial /etc/pipy/tutorial
 RUN apk add --no-cache ca-certificates libstdc++ libcap su-exec tar curl busybox-extras iptables tzdata socat logrotate 
 RUN adduser -Su 1340 pipy \
     && chmod -R g=u /usr/local/bin/pipy /etc/pipy \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,46 @@
 #!/bin/sh
 set -e
 
-export PIPY_SPAWN=${PIPY_SPAWN:-0}
+function set_pipy_spawn() {
+  # cgroup v1
+  if [ -f "/sys/fs/cgroup/cpu/cpu.cfs_quota_us" ]
+  then
+    QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+    PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+  fi
+
+  # cgroup v2
+  if [ -f "/sys/fs/cgroup/cpu.max" ]
+  then
+    QUOTA=$(cut -d ' ' -f 1 /sys/fs/cgroup/cpu.max)
+    PERIOD=$(cut -d ' ' -f 2 /sys/fs/cgroup/cpu.max)
+  fi
+
+  if [ "$QUOTA" = "-1" ] || [ "$QUOTA" = "max" ]
+  then
+    export DEFAULT_SPAWN=0
+  else
+    export DEFAULT_SPAWN=$((QUOTA/$PERIOD - 1))
+  fi
+
+  export PIPY_SPAWN=${PIPY_SPAWN:-$DEFAULT_SPAWN}
+}
+
+if [ $(readlink /proc/$$/ns/pid) = $(readlink /proc/1/ns/pid) ]
+then
+  # in container
+  set_pipy_spawn
+
+  # workaround for https://github.com/moby/moby/issues/31243
+  chmod o+w /proc/self/fd/1 || true
+  chmod o+w /proc/self/fd/2 || true
+fi
 
 if [[ "$1" == "pipy" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1 || true
-    chmod o+w /proc/self/fd/2 || true
-
     if [ "${PIPY_CONFIG_FILE}x" == 'x' ]; then
-      PIPY_CONFIG_FILE=/etc/pipy/test/001-echo/pipy.js
+      PIPY_CONFIG_FILE=/etc/pipy/tutorial/02-echo/hello.js
     fi
     if [ "$(id -u)" != "0" ]; then
       for i in $(seq 1 1 $PIPY_SPAWN); do
@@ -24,6 +53,11 @@ if [[ "$1" == "pipy" ]]; then
       done
       exec su-exec pipy /usr/local/bin/pipy ${PIPY_CONFIG_FILE} --reuse-port 
     fi
+  else
+    for i in $(seq 1 1 $PIPY_SPAWN); do
+      exec "$@" --reuse-port &
+    done
+    exec "$@" --reuse-port
   fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,7 @@ function set_pipy_spawn() {
   then
     export DEFAULT_SPAWN=0
   else
-    export DEFAULT_SPAWN=$((QUOTA/$PERIOD - 1))
+    export DEFAULT_SPAWN=$(($QUOTA/$PERIOD - 1))
   fi
 
   export PIPY_SPAWN=${PIPY_SPAWN:-$DEFAULT_SPAWN}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,7 @@ then
   chmod o+w /proc/self/fd/2 || true
 fi
 
-if [[ "$1" == "pipy" ]]; then
+if [[ "$1" == "pipy" || "$1" == "/usr/local/bin/pipy" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     if [ "${PIPY_CONFIG_FILE}x" == 'x' ]; then


### PR DESCRIPTION
Currently we only start one pipy instance in sidecar, this change allow container start multiple pipy instance based on the CPU limit.