### PR TITLE
Avoid multiple set_pending on Endpoint::StreamBase.

### DIFF
--- a/src/filters/http2.cpp
+++ b/src/filters/http2.cpp
@@ -1857,6 +1857,7 @@ void Endpoint::StreamBase::set_clearing(bool clearing) {
         m_endpoint->m_streams_pending.remove(this);
         if (m_send_buffer.empty()) {
           m_endpoint->m_streams.push(this);
+          m_is_pending = false;
         } else {
           m_endpoint->m_streams_pending.push(this);
         }


### PR DESCRIPTION
Fixed http2 stream bug, avoid multiple set_pending on Endpoint::StreamBase. 
