### PR TITLE
[fix] package binary only, without the dictionaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -202,7 +202,7 @@ if $BUILD_BINARY; then
   if $PACKAGE_OUTPUTS; then
     mkdir -p ${PIPY_DIR}/buildroot/usr/local/bin
     cp -a ${PIPY_DIR}/bin/pipy ${PIPY_DIR}/buildroot/usr/local/bin/pipy
-    tar zcv -f ${PKG_NAME}-${RELEASE_VERSION}-${OS_NAME}-${OS_ARCH}.tar.gz -C ${PIPY_DIR}/buildroot .
+    tar zcv -f ${PKG_NAME}-${RELEASE_VERSION}-${OS_NAME}-${OS_ARCH}.tar.gz -C ${PIPY_DIR}/buildroot usr/local/bin/pipy
     rm -rf ${PIPY_DIR}/buildroot
   fi
 fi


### PR DESCRIPTION
there are 3 dictionaries packaged into the tar file accidentally, fix it and add binary only.

```
a .
a ./usr
a ./usr/local
a ./usr/local/bin
```