### PR TITLE
[ci] fix node version issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 as builder
+FROM alpine:3.16.1 as builder
 LABEL maintainer="Kevein Liu<khas@flomesh.io>"
 
 ENV  pkg_prefix              /usr/local
@@ -28,14 +28,13 @@ ENV PIPY_STATIC=${PIPY_STATIC:-OFF}
 ARG BUILD_TYPE
 ENV BUILD_TYPE=${BUILD_TYPE:-Release}
 
-ENV NODE_VER=14.19.0-r0
-ENV NPM_VER=7.17.0-r0
-
 COPY . /pipy
 
-RUN apk add --no-cache --virtual .build-deps openssh-client cmake clang alpine-sdk linux-headers autoconf automake libtool tiff jpeg zlib zlib-dev pkgconf nasm file musl-dev nodejs=${NODE_VER} npm=${NPM_VER} 
+RUN apk add --no-cache --virtual .build-deps openssh-client cmake clang \
+    alpine-sdk linux-headers autoconf automake libtool tiff jpeg zlib \
+    zlib-dev pkgconf nasm file musl-dev
 
-RUN if [ "$PIPY_GUI" == "ON" ] ; then cd pipy && npm install && npm run build; fi
+RUN if [ "$PIPY_GUI" == "ON" ] ; then apk add --no-cache nodejs npm && cd pipy && npm install && npm run build; fi
 
 RUN rm -fr pipy/build \
     && mkdir pipy/build \
@@ -50,7 +49,7 @@ RUN rm -fr pipy/build \
     && apk del .build-deps
 
 
-FROM alpine:3.14 as prod
+FROM alpine:3.16.1 as prod
 COPY --from=builder /pipy/bin/pipy /usr/local/bin/pipy
 COPY --from=builder /pipy/tutorial /etc/pipy/tutorial
 RUN apk add --no-cache ca-certificates libstdc++ libcap su-exec tar curl busybox-extras iptables tzdata socat logrotate 


### PR DESCRIPTION
* Bump base image version to alpine:3.16.1, which fix the CVE-2022-2097
* Do not install node if PIPY_GUI is OFF
* Use the latest node version(`16.16.0-r0`) in the alpine repo