### PR TITLE
[ci] add missing BuildRequires

### DIFF
--- a/rpm/pipy.spec
+++ b/rpm/pipy.spec
@@ -7,7 +7,17 @@ Summary: 	Pipy is a programmable network proxy for the cloud, edge and IoT.
 License: 	NEU License
 Source0: 	pipy.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{revision}-root-%(%{__id_u} -n)
+BuildRequires: 	/usr/bin/chrpath
+BuildRequires: 	autoconf
+BuildRequires: 	automake
+BuildRequires: 	clang
 BuildRequires: 	cmake3
+BuildRequires: 	gcc
+BuildRequires: 	make
+BuildRequires: 	nodejs-packaging
+BuildRequires: 	perl-interpreter
+BuildRequires: 	perl(Module::Load::Conditional), perl(File::Temp)
+BuildRequires: 	zlib-devel
 #AutoReqProv: no
 %define revision %{release}
 %define prefix /usr/local


### PR DESCRIPTION
there are couple missing BuildRequires not specified by the .spec recipe. without them, mock is not able to build the rpm package in a clean room environment.

tested on rockylinux-9 using:

```console
$ VERSION=0.70.0 REVISION=1 rpmbuild -bs *.spec
$ mock --verbose --rebuild $HOME/rpmbuild/SRPMS/pipy-0.70.0-1.src.rpm
```

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
