### PR TITLE
[ci]: use llvm-toolset-7.0-clang instead of clang on el7

### DIFF
--- a/rpm/pipy.spec
+++ b/rpm/pipy.spec
@@ -10,7 +10,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{revision}-root-%(%{__id_u} -n)
 BuildRequires: 	/usr/bin/chrpath
 BuildRequires: 	autoconf
 BuildRequires: 	automake
+%if 0%{?rhel} >= 8 || 0%{?fedora}
 BuildRequires: 	clang
+%else
+BuildRequires: 	llvm-toolset-7.0-clang
+%endif
 BuildRequires: 	cmake3
 BuildRequires: 	gcc
 BuildRequires: 	make


### PR DESCRIPTION
as llvm-toolset-7.0-clang does not provide clang, let's BuildRequires it directly.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
