### PR TITLE
[ci] add rpmbuild option of --with gui

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -40,15 +40,20 @@ RUN yum install -y -q gcc make unzip rpm-build rpmdevtools chrpath expat-devel z
 
 RUN mv /pipy.tar.gz ~/rpmbuild/SOURCES \
     && mv /pipy.spec ~/rpmbuild/SPECS \
-    && export CI_COMMIT_SHA \
+    && spectool -g -R ~/rpmbuild/SPECS/pipy.spec
+
+RUN if test "$PIPY_GUI" = ON ; then   \
+      rpmbuild_opts=' --with gui';    \
+    else                              \
+      rpmbuild_opts=' --without gui'; \
+    fi;                               \
+       export CI_COMMIT_SHA \
     && export CI_COMMIT_TAG=${VERSION}-${REVISION} \
     && export CI_COMMIT_DATE \
-    && export PIPY_GUI \
     && export PIPY_STATIC \
     && export BUILD_TYPE \
-    && spectool -g -R ~/rpmbuild/SPECS/pipy.spec \
     && PATH="/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin${PATH:+:${PATH}}" \
-    && rpmbuild -ba ~/rpmbuild/SPECS/pipy.spec \
+    && rpmbuild $rpmbuild_opts -ba ~/rpmbuild/SPECS/pipy.spec \
     && mkdir /rpm \
     && find ~/rpmbuild/RPMS -name pipy*.rpm -exec mv {} /rpm/ \;
 

--- a/rpm/pipy.spec
+++ b/rpm/pipy.spec
@@ -1,3 +1,4 @@
+%bcond_with gui
 Name:		pipy
 Version: 	%{getenv:VERSION}
 Release: 	%{getenv:REVISION}%{?dist}
@@ -18,7 +19,9 @@ BuildRequires: 	llvm-toolset-7.0-clang
 BuildRequires: 	cmake3
 BuildRequires: 	gcc
 BuildRequires: 	make
+%if 0%{with gui}
 BuildRequires: 	nodejs-packaging
+%endif
 BuildRequires: 	perl-interpreter
 BuildRequires: 	perl(Module::Load::Conditional), perl(File::Temp)
 BuildRequires: 	zlib-devel
@@ -38,12 +41,16 @@ Pipy is a tiny, high performance, highly stable, programmable proxy.
 rm -fr pipy/build
 %{__mkdir} pipy/build
 cd pipy
-if [ $PIPY_GUI == "ON" ] ; then
+%if 0%{with gui}
   npm install
   npm run build
-fi
+%endif
 cd build
-CXX=clang++ CC=clang cmake3 -DPIPY_GUI=${PIPY_GUI} -DPIPY_STATIC=${PIPY_STATIC} -DPIPY_SAMPLES=${PIPY_GUI} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+CXX=clang++ CC=clang cmake3 \
+  -DPIPY_GUI==%{?with_gui:ON}%{?!with_gui:OFF} \
+  -DPIPY_SAMPLES=%{?with_gui:ON}%{?!with_gui:OFF} \
+  -DPIPY_STATIC=${PIPY_STATIC} \
+  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 make -j$(getconf _NPROCESSORS_ONLN)
 
 %preun


### PR DESCRIPTION
so we can install nodejs only if `--with gui` is passed to rpmbuild.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
