### PR TITLE
[ci] fix rpm build error

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -45,12 +45,12 @@ RUN if test "$PIPY_GUI" = ON ; then   \
     else                              \
       rpmbuild_opts=' --without gui'; \
     fi;                               \
-       export CI_COMMIT_SHA \
+    export CI_COMMIT_SHA \
     && export CI_COMMIT_TAG=${VERSION}-${REVISION} \
     && export CI_COMMIT_DATE \
     && export PIPY_STATIC \
     && export BUILD_TYPE \
-    && PATH="/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin${PATH:+:${PATH}}" \
+    && source /opt/rh/llvm-toolset-7.0/enable \
     && rpmbuild $rpmbuild_opts \
          --define "pipy_version $VERSION" \
          --define "pipy_revision $REVISION" \

--- a/rpm/pipy.spec
+++ b/rpm/pipy.spec
@@ -25,7 +25,7 @@ BuildRequires: 	llvm-toolset-7.0-clang
 BuildRequires: 	cmake3
 BuildRequires: 	gcc
 BuildRequires: 	make
-%if 0%{with gui}
+%if %{with gui}
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 BuildRequires: 	npm
 %else
@@ -51,7 +51,7 @@ Pipy is a tiny, high performance, highly stable, programmable proxy.
 rm -fr pipy/build
 %{__mkdir} pipy/build
 cd pipy
-%if 0%{with gui}
+%if %{with gui}
 %if 0%{?rhel} == 7
 source /opt/rh/rh-nodejs14/enable
 %endif
@@ -60,8 +60,8 @@ source /opt/rh/rh-nodejs14/enable
 %endif
 cd build
 CXX=clang++ CC=clang cmake3 \
-  -DPIPY_GUI==%{?with_gui:ON}%{?!with_gui:OFF} \
-  -DPIPY_SAMPLES=%{?with_gui:ON}%{?!with_gui:OFF} \
+  -DPIPY_GUI=%{?with_gui:ON}%{!?with_gui:OFF} \
+  -DPIPY_SAMPLES=%{?with_gui:ON}%{!?with_gui:OFF} \
   -DPIPY_STATIC=${PIPY_STATIC} \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 make -j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
fix issues:
* Compiler not found in PATH, the path of llvm-toolset should be `/opt/rh/llvm-toolset-7.0/` instead of `/opt/rh/llvm-toolset-7`
* Syntax issue in `pipy.spec`, s/-DPIPY_GUI==/-DPIPY_GUI=/