### PR TITLE
[build] check before adding -Wno-delete-non-abstract-non-virtual-dtor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,10 +116,16 @@ add_definitions(
   -DPIPY_HOST="${CMAKE_HOST_SYSTEM} ${CMAKE_HOST_SYSTEM_PROCESSOR}"
 )
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-Wdelete-non-abstract-non-virtual-dtor"
+  COMPILER_SUPPORTS_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR)
+if(COMPILER_SUPPORTS_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-delete-non-abstract-non-virtual-dtor>)
+endif()
 add_compile_options(
   -Wall
   -Wno-overloaded-virtual
-  -Wno-delete-non-abstract-non-virtual-dtor
   -Wno-delete-non-virtual-dtor
   -Wno-sign-compare
 )


### PR DESCRIPTION
-Wdelete-non-abstract-non-virtual-dtor was split into two groups back into https://reviews.llvm.org/D56405. but this change has not backported to llvm-toolset-7, which in turn packages Clang/LLVM 5.x.

to avoid the unknown warning options warning messages from the compiler when compiling the tree on el7, we need to check for the existence of this warning option before using it.

in this change,

* check for the existence of the "-Wdelete-non-abstract-non-virtual-dtor", before disabling it.
* only apply this option on C++ source files. as strictly speaking, this option only applies to C++.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
