### PR TITLE
Updated README.md. Removed Katacoda and added Docker Extension Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open the browser of your choice, point to `http://localhost:6060`. You will now 
   * [PipyJS Reference](https://flomesh.io/pipy/docs/reference/pjs)
 * Learning Resources
   * [Blog](https://blog.flomesh.io/)
-  * [Katacoda](https://katacoda.com/flomesh-io) - Katacoda scenarios
+  * [Docker Desktop Extension](https://open.docker.com/extensions/marketplace?extensionId=flomesh/pipy-docker-ext) - Flomesh Pipy Docker Desktop Extension
   * [InfoQ article](https://www.infoq.com/articles/network-proxy-stream-processor-pipy/) - Brief Introduction
 * [Copyright](COPYRIGHT)
 * [Licence](LICENCE)


### PR DESCRIPTION
* Removed Katacoda link (Katacoda.com is sunset)
* Added Pipy Docker Desktop Extension installation link