### PR TITLE
[fix] setsockopt errno 22

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -857,7 +857,7 @@ auto Socket::set_raw_option(int level, int option, Data *data) -> int {
   if (!m_fd) throw std::runtime_error("socket is gone");
   pjs::vl_array<char, 1000> buf(data->size());
   data->to_bytes((uint8_t *)buf.data());
-  auto ret = setsockopt(m_fd, level, option, buf.data(), buf.size());
+  auto ret = setsockopt(m_fd, level, option, buf.data(), 4 * buf.size());
   if (!ret) return ret;
   return errno;
 }


### PR DESCRIPTION
fix https://github.com/flomesh-io/pipy/issues/188#issuecomment-2209124974

seems like `setsockopt()` will regard **buf.data()** as **(int\*)**? I'm not quite sure, however this commit will make the function return no error code.

### Test

On the server side:
```shell
pipy -e 'pipy().listen(8000).connect('127.0.0.1:1234')'
```

On the client side:
```js
pipy().task().onStart(new Message('Turn around')).connect('127.0.0.1:8000', {
	onState: (conn) => {
		if(conn.state === 'open') {
			console.info(conn.socket.setRawOption(1, 15, new Data([1])))
		}
	},
	bind: '127.0.0.1:1234'
})
.listen('127.0.0.1:1234').print()
```

The result we shall got:
![图片](https://github.com/flomesh-io/pipy/assets/71858127/4de5b588-060c-43cb-9119-3c41518c0120)

