### PR TITLE
[ci] fix pipy version string in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ ENV  pkg_bindir              ${pkg_prefix}/bin
 ENV  CXX       		     clang++
 ENV  CC			     clang
 
-ARG VERSION
-ENV VERSION=${VERSION}
-
-ARG REVISION
-ENV REVISION=${REVISION}
+ARG COMMIT_TAG
+ENV CI_COMMIT_TAG=${COMMIT_TAG}
 
 ARG COMMIT_ID
 ENV CI_COMMIT_SHA=${COMMIT_ID}
@@ -40,7 +37,7 @@ RUN rm -fr pipy/build \
     && mkdir pipy/build \
     && cd pipy/build \
     && export CI_COMMIT_SHA \
-    && export CI_COMMIT_TAG=${VERSION}-${REVISION} \
+    && export CI_COMMIT_TAG \
     && export CI_COMMIT_DATE \
     && cmake -DPIPY_GUI=${PIPY_GUI} -DPIPY_STATIC=${PIPY_STATIC} -DPIPY_CODEBASES=${PIPY_GUI} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .. \
     && make -j$(getconf _NPROCESSORS_ONLN) \

--- a/build.sh
+++ b/build.sh
@@ -265,8 +265,7 @@ if $BUILD_CONTAINER; then
   echo "Build image ${IMAGE}:$IMAGE_TAG"
   sudo docker build --rm -t ${IMAGE}:$IMAGE_TAG \
     --network=host \
-    --build-arg VERSION=$VERSION \
-    --build-arg REVISION=$REVISION \
+    --build-arg COMMIT_TAG=$RELEASE_VERSION \
     --build-arg COMMIT_ID=$COMMIT_ID \
     --build-arg COMMIT_DATE="$COMMIT_DATE" \
     --build-arg PIPY_GUI="$PIPY_GUI" \

--- a/multi_arch_images_build.sh
+++ b/multi_arch_images_build.sh
@@ -111,8 +111,7 @@ for arch in "${ARCHS[@]}"; do
     # 构建镜像
     docker buildx build --platform $arch -t ${IMAGE}:${IMAGE_TAG}-$arch_name \
         --network=host \
-        --build-arg VERSION=$VERSION \
-        --build-arg REVISION=$REVISION \
+        --build-arg COMMIT_TAG=$RELEASE_VERSION \
         --build-arg COMMIT_ID=$COMMIT_ID \
         --build-arg COMMIT_DATE="$COMMIT_DATE" \
         --build-arg PIPY_GUI="$PIPY_GUI" \


### PR DESCRIPTION
Current pipy version of docker image would should duplicate tag, e.g. `1.5.9-1.5.9`

```
Version          : 1.5.9-1.5.9
Commit           : ddd5f55915eaca575ac782c4a12c0e3110d3d5e2
Commit Date      : Mon, 13 Jan 2025 21:03:36 +0800
Host             : Linux-6.8.0-1017-azure x86_64
OpenSSL          : OpenSSL 3.2.0 23 Nov 2023
OpenSSL Conf     : /usr/local/ssl/openssl.cnf
Builtin GUI      : No
Builtin Codebases: No
```

This PR would remove the duplicate part.