### PR TITLE
[chore] migrate OpenSSL build to ExternalProject_Add

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,32 +159,30 @@ else()
   set(OPENSSL_LIB_DIR ${OPENSSL_SRC_DIR}/build)
   set(OPENSSL_INC_DIR ${OPENSSL_SRC_DIR}/include ${OPENSSL_LIB_DIR}/include)
 
-  file(MAKE_DIRECTORY "${OPENSSL_SRC_DIR}/build")
+  include(ExternalProject)
 
   if(WIN32)
-    add_custom_command(
-      OUTPUT ${OPENSSL_LIB_DIR}/${LIB_CRYPTO} ${OPENSSL_LIB_DIR}/${LIB_SSL}
-      WORKING_DIRECTORY ${OPENSSL_SRC_DIR}/build
-      COMMAND cmd ARGS /C set
-      COMMAND perl ARGS ../Configure no-shared no-tests VC-WIN64A
-      COMMAND nmake
-      VERBATIM
-      COMMENT "Building OpenSSL"
-    )
+    set(configure_command perl
+      <SOURCE_DIR>/Configure no-shared no-tests VC-WIN64A)
+    set(make_command nmake)
   else()
-    add_custom_command(
-      OUTPUT ${OPENSSL_LIB_DIR}/${LIB_CRYPTO} ${OPENSSL_LIB_DIR}/${LIB_SSL}
-      WORKING_DIRECTORY ${OPENSSL_SRC_DIR}
-      COMMAND mkdir -p ${OPENSSL_SRC_DIR}/build
-      COMMAND cd ${OPENSSL_SRC_DIR}/build && CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ../config no-shared no-tests && make -j2
-      VERBATIM
-      COMMENT "Building OpenSSL"
-    )
+    set(configure_command ${CMAKE_COMMAND} -E env
+      CC=${CMAKE_C_COMPILER}
+      CXX=${CMAKE_CXX_COMPILER}
+      AR=${CMAKE_AR}
+      RANLIB=${CMAKE_RANLIB}
+      <SOURCE_DIR>/Configure no-shared no-tests)
+    set(make_command make)
   endif()
-endif()
 
-if(NOT PIPY_USE_SYSTEM_OPENSSL)
-  add_custom_target(OpenSSL DEPENDS ${OPENSSL_LIB_DIR}/${LIB_CRYPTO} ${OPENSSL_LIB_DIR}/${LIB_SSL})
+  ExternalProject_Add(OpenSSL
+    SOURCE_DIR ${OPENSSL_SRC_DIR}
+    BINARY_DIR ${OPENSSL_LIB_DIR}
+    CONFIGURE_COMMAND "${configure_command}"
+    BUILD_COMMAND "${build_command}"
+    BUILD_BYPRODUCTS ${OPENSSL_LIB_DIR}/${LIB_CRYPTO} ${OPENSSL_LIB_DIR}/${LIB_SSL}
+    INSTALL_COMMAND ""
+  )
 endif()
 
 set(BROTLI_BUNDLED_MODE ON CACHE BOOL "" FORCE)
@@ -394,10 +392,6 @@ add_custom_target(GenVer DEPENDS ${CMAKE_BINARY_DIR}/deps/version.h)
 add_custom_target(BuiltinCodebases DEPENDS ${CMAKE_BINARY_DIR}/deps/codebases.br.h)
 
 add_dependencies(pipy yajl_s expat ${BROTLI_LIB} GenVer BuiltinCodebases)
-
-if(NOT PIPY_USE_SYSTEM_OPENSSL)
-  add_dependencies(pipy OpenSSL)
-endif()
 
 if(NOT PIPY_USE_SYSTEM_ZLIB)
   add_dependencies(pipy ${ZLIB_LIB})


### PR DESCRIPTION
Replace manual OpenSSL build configuration that used add_custom_command() and add_custom_target() with ExternalProject_Add() for better dependency management and readability.

This change also consolidates Windows and non-Windows build paths to reduce code duplication and simplify maintenance.

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
