### PR TITLE
[build] Export OpenSSL as proper CMake libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,11 @@ else()
   set(OPENSSL_LIB_DIR ${OPENSSL_SRC_DIR}/build)
   set(OPENSSL_INC_DIR ${OPENSSL_SRC_DIR}/include ${OPENSSL_LIB_DIR}/include)
 
+  # Create the OpenSSL build/include directory early to avoid CMake configuration errors
+  # This is needed because CMake validates INTERFACE_INCLUDE_DIRECTORIES paths during configuration,
+  # but ExternalProject creates these directories only during build time
+  file(MAKE_DIRECTORY ${OPENSSL_LIB_DIR}/include)
+
   include(ExternalProject)
 
   if(WIN32)
@@ -184,6 +189,23 @@ else()
     INSTALL_COMMAND ""
   )
 endif()
+
+foreach(component Crypto SSL)
+  string(TOLOWER ${component} lower_c)
+  set(lib OpenSSL::${component})
+  if(NOT TARGET ${lib})
+    add_library(${lib} STATIC IMPORTED)
+    set_target_properties(${lib} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INC_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION ${OPENSSL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lower_c}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    if(TARGET OpenSSL::SSL AND TARGET OpenSSL::Crypto)
+      set_target_properties(OpenSSL::SSL PROPERTIES
+        INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
+    endif()
+    add_dependencies(${lib} OpenSSL)
+  endif()
+endforeach()
 
 set(BROTLI_BUNDLED_MODE ON CACHE BOOL "" FORCE)
 set(BROTLI_DISABLE_TESTS ON CACHE BOOL "" FORCE)
@@ -449,15 +471,10 @@ target_link_libraries(
   yajl_s
   yaml
   expat
+  OpenSSL::SSL
   ${ZLIB_LIB}
   ${BROTLI_LIB}
 )
-
-if(PIPY_USE_SYSTEM_OPENSSL)
-  target_link_libraries(pipy ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
-else()
-  target_link_libraries(pipy ${OPENSSL_LIB_DIR}/${LIB_SSL} ${OPENSSL_LIB_DIR}/${LIB_CRYPTO})
-endif()
 
 if(WIN32)
   target_link_libraries(pipy crypt32 userenv)


### PR DESCRIPTION
Fix build dependency issue introduced in 786fb57a where switching to ExternalProject_Add for OpenSSL also removed the dependency declaration:

    add_dependencies(pipy OpenSSL)

This caused build failures because pipy requires OpenSSL header files, including generated headers from OpenSSL's build process.

Solution: Create proper CMake OpenSSL library targets that depend on the OpenSSL build target. This ensures correct build ordering and allows linking against OpenSSL through CMake targets instead of raw library files.

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
