### PR TITLE
[fix] PQC for both key exchange and signature algorithms

### DIFF
--- a/docs/dts/Configuration.d.ts
+++ b/docs/dts/Configuration.d.ts
@@ -43,7 +43,6 @@ interface CertificateOptions {
 interface PqcOptions {
   /**
    * Key exchange algorithm for post-quantum cryptography.
-   * Defaults to "ML-KEM-512" if not specified and pqc is enabled.
    * Available algorithms depend on OpenSSL version:
    * - OpenSSL >= 3.2: Both key exchange and signature algorithms supported
    */
@@ -51,7 +50,6 @@ interface PqcOptions {
   
   /**
    * Signature algorithm for post-quantum cryptography.
-   * Defaults to "ML-DSA-44" if not specified and pqc is enabled.
    * Available when OpenSSL version >= 3.5.
    */
   signature?:

--- a/src/filters/tls.hpp
+++ b/src/filters/tls.hpp
@@ -84,7 +84,6 @@ struct Options : public pipy::Options {
 #endif
 #ifdef PIPY_USE_PQC
   PqcOptions pqc;
-  bool pqc_enabled = false;
 #endif
 
   Options() {}


### PR DESCRIPTION
Previously, when the `pqc` suboption was specified in acceptTLS() options, we would automatically assign default PQC algorithms for both key exchange and signature, even when only one was explicitly configured. This prevented users from mixing PQC and traditional algorithms.

Now we only apply PQC defaults to explicitly unspecified algorithms, allowing users to:
- Use PQC for key exchange with traditional signature algorithms
- Use traditional certificates while enabling PQC key exchange
- Have fine-grained control over which cryptographic operations use PQC

This change maintains backward compatibility while providing the flexibility to adopt PQC incrementally rather than requiring full PQC adoption.

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
