### PR TITLE
[fix] use hardcoded "lib" prefix for OpenSSL library names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,18 +90,15 @@ endif()
 
 if(WIN32)
   set(LIB_Z zlib.lib)
-  set(LIB_CRYPTO libcrypto.lib)
-  set(LIB_SSL libssl.lib)
-  set(LIB_BROTLI libbrotlidec-static.lib)
   set(EXT_SHELL cmd)
   set(EXE_PACK "Release\\pack.exe")
 else(WIN32)
   set(LIB_Z libz.a)
-  set(LIB_CRYPTO libcrypto.a)
-  set(LIB_SSL libssl.a)
-  set(LIB_BROTLI libbrotlidec-static.a)
   set(EXT_SHELL sh)
   set(EXE_PACK pack)
+endif(WIN32)
+set(LIB_BROTLI libbrotlidec-static${CMAKE_STATIC_LIBRARY_SUFFIX})
+
 endif(WIN32)
 
 if(PIPY_ZLIB)
@@ -185,7 +182,7 @@ else()
     BINARY_DIR ${OPENSSL_LIB_DIR}
     CONFIGURE_COMMAND "${configure_command}"
     BUILD_COMMAND "${make_command}"
-    BUILD_BYPRODUCTS ${OPENSSL_LIB_DIR}/${LIB_CRYPTO} ${OPENSSL_LIB_DIR}/${LIB_SSL}
+    BUILD_BYPRODUCTS ${OPENSSL_LIB_DIR}/libcrypto${CMAKE_STATIC_LIBRARY_SUFFIX} ${OPENSSL_LIB_DIR}/libssl${CMAKE_STATIC_LIBRARY_SUFFIX}
     INSTALL_COMMAND ""
   )
 endif()
@@ -339,7 +336,7 @@ foreach(component Crypto SSL)
     set_target_properties(${lib} PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INC_DIR}"
       IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-      IMPORTED_LOCATION ${OPENSSL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lower_c}${CMAKE_STATIC_LIBRARY_SUFFIX})
+      IMPORTED_LOCATION ${OPENSSL_LIB_DIR}/lib${lower_c}${CMAKE_STATIC_LIBRARY_SUFFIX})
     if(TARGET OpenSSL::SSL AND TARGET OpenSSL::Crypto)
       set_target_properties(OpenSSL::SSL PROPERTIES
         INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)


### PR DESCRIPTION
OpenSSL uses Unix-style naming convention with "lib" prefix for its static libraries on all platforms, including Windows (libssl.lib, libcrypto.lib), rather than following platform-specific conventions.

Commit edfcdc3a introduced CMake imported targets for OpenSSL but used CMAKE_STATIC_LIBRARY_PREFIX, which is empty on Windows, causing the build to look for ssl.lib/crypto.lib instead of libssl.lib/libcrypto.lib.

This change hardcodes the "lib" prefix when constructing OpenSSL library paths to match OpenSSL's cross-platform naming convention.

This change should fix the Win32 build failure when linking against OpenSSL 3.5.2

We thank you for helping improve Pipy. In order to ease the reviewing process, we invite you to read the [guidelines](https://https://github.com/flomesh-io/pipy/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team. In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
